### PR TITLE
Update HID MTU Size

### DIFF
--- a/internal_include/bt_target.h
+++ b/internal_include/bt_target.h
@@ -1151,7 +1151,7 @@
 #endif
 
 #ifndef HID_DEV_MTU_SIZE
-#define HID_DEV_MTU_SIZE 64
+#define HID_DEV_MTU_SIZE 512
 #endif
 
 #ifndef HID_DEV_FLUSH_TO


### PR DESCRIPTION
Hi,

I present to you a little modification, that should have no drawback on any of your supported device.
This MTU update, improve again MTU size, default android is 23 and you brought it to 64 nearly 6 years ago when adding HID.

This fix is already used by Samsung on all HID capable bluetooth phone, and other rom builder started to do it too like Evolution-X

Why this update ? Equipment using HID have evolved during those 6 years and I don't deny it : 99% of them would work flawlessly with MTU to 64. But some other require now a little more... Like the Nintendo joycon when sending data that it just read to the console it need an MTU of nearly 300. And doing some research on the subject I saw that some dev have problem with the default limitation of 23 so to me it's a matter of time before MTU will be set higher by default. This pull request will just be ahead of time :)

Hope you will understand my concern but I will totally understand if you deny it.

Have a great day !